### PR TITLE
Voorstel tot kleine wijziging

### DIFF
--- a/pra.streams05.CORE/PostalCode.cs
+++ b/pra.streams05.CORE/PostalCode.cs
@@ -4,7 +4,7 @@ using System.Text;
 
 namespace pra.streams05.CORE
 {
-    public class PostalCodes
+    public class PostalCode
     {
         public string zip { get; set; }
         public string city { get; set; }

--- a/pra.streams05.CORE/PostalCode.cs
+++ b/pra.streams05.CORE/PostalCode.cs
@@ -6,9 +6,9 @@ namespace pra.streams05.CORE
 {
     public class PostalCode
     {
-        public string zip { get; set; }
-        public string city { get; set; }
-        public double lng { get; set; }
-        public double lat { get; set; }
+        public string Zip { get; set; }
+        public string City { get; set; }
+        public double Lng { get; set; }
+        public double Lat { get; set; }
     }
 }

--- a/pra.streams05.CORE/PresidentInfo.cs
+++ b/pra.streams05.CORE/PresidentInfo.cs
@@ -4,7 +4,7 @@ using System.Text;
 
 namespace pra.streams05.CORE
 {
-    public class Presidents
+    public class PresidentInfo
     {
         public int ID { get; set; }
         public int President { get; set; }

--- a/pra.streams05.WPF/MainWindow.xaml.cs
+++ b/pra.streams05.WPF/MainWindow.xaml.cs
@@ -42,7 +42,7 @@ namespace pra.streams05.WPF
 
         private void btnPostcodes_Click(object sender, RoutedEventArgs e)
         {
-            List<PostalCode> postalCodes; ;
+            List<PostalCode> postalCodes;
             var json = new WebClient().DownloadString("https://raw.githubusercontent.com/jief/zipcode-belgium/master/zipcode-belgium.json");
             postalCodes = JsonConvert.DeserializeObject<List<PostalCode>>(json);
             dgrPost.ItemsSource = postalCodes;

--- a/pra.streams05.WPF/MainWindow.xaml.cs
+++ b/pra.streams05.WPF/MainWindow.xaml.cs
@@ -34,7 +34,7 @@ namespace pra.streams05.WPF
             // https://mysafeinfo.com/api/data?list=presidents&format=jsonp
 
             var inhoud = new WebClient().DownloadString("https://mysafeinfo.com/api/data?list=presidents&format=json");
-            List<PresidentInfo> presidenten = new List<PresidentInfo>();
+            List<PresidentInfo> presidenten;
             presidenten = JsonConvert.DeserializeObject<List<PresidentInfo>>(inhoud);
             dgrPresident.ItemsSource = presidenten;
 
@@ -42,7 +42,7 @@ namespace pra.streams05.WPF
 
         private void btnPostcodes_Click(object sender, RoutedEventArgs e)
         {
-            List<PostalCode> postalCodes = new List<PostalCode>();
+            List<PostalCode> postalCodes; ;
             var json = new WebClient().DownloadString("https://raw.githubusercontent.com/jief/zipcode-belgium/master/zipcode-belgium.json");
             postalCodes = JsonConvert.DeserializeObject<List<PostalCode>>(json);
             dgrPost.ItemsSource = postalCodes;

--- a/pra.streams05.WPF/MainWindow.xaml.cs
+++ b/pra.streams05.WPF/MainWindow.xaml.cs
@@ -34,17 +34,17 @@ namespace pra.streams05.WPF
             // https://mysafeinfo.com/api/data?list=presidents&format=jsonp
 
             var inhoud = new WebClient().DownloadString("https://mysafeinfo.com/api/data?list=presidents&format=json");
-            List<Presidents> presidenten = new List<Presidents>();
-            presidenten = JsonConvert.DeserializeObject<List<Presidents>>(inhoud);
+            List<PresidentInfo> presidenten = new List<PresidentInfo>();
+            presidenten = JsonConvert.DeserializeObject<List<PresidentInfo>>(inhoud);
             dgrPresident.ItemsSource = presidenten;
 
         }
 
         private void btnPostcodes_Click(object sender, RoutedEventArgs e)
         {
-            List<PostalCodes> postalCodes = new List<PostalCodes>();
+            List<PostalCode> postalCodes = new List<PostalCode>();
             var json = new WebClient().DownloadString("https://raw.githubusercontent.com/jief/zipcode-belgium/master/zipcode-belgium.json");
-            postalCodes = JsonConvert.DeserializeObject<List<PostalCodes>>(json);
+            postalCodes = JsonConvert.DeserializeObject<List<PostalCode>>(json);
             dgrPost.ItemsSource = postalCodes;
         }
     }


### PR DESCRIPTION
Ik heb een paar kleine wijzigingen doorgevoerd:

- Entity klassen hernoemd zodat ze in het enkelvoud staan:
   - `PostalCode` beschrijft 1 postcode.
   - `PresidentInfo` beschrijft info over 1 president. Hier kon ik niet gewoon `President` gebruiken omdat er een gelijknamige property is en dit conflicteert.
- Onnodige initialisatie van de lists verwijderd. De lege lijsten werden overschreven door de nieuwe lijst die je terugkrijgt bij het parsen van de JSON.
- Properties van `PostalCode` hernoemd zodat ze beginnen met een hoofdletter. De keys in de JSON zijn lower case maar dit levert geen problemen op bij het parsen aangezien dat case insensitive gebeurt.

@jandedeurwaerder-howest Indien je akkoord gaat met deze wijzigingen, pas je dan ook het voorbeeld over de postcodes in de cursus aan met dezelfde wijzigingen? Als je dat liever hebt, wil ik gerust ook zelf de code in de cursus aanpassen.